### PR TITLE
Enable GRPC Connection pooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+*.iml
 
 # Test binary, built with `go test -c`
 *.test

--- a/capture.go
+++ b/capture.go
@@ -38,6 +38,7 @@ func (s *Speakeasy) handleRequestResponse(w http.ResponseWriter, r *http.Request
 }
 
 func (s *Speakeasy) handleRequestResponseError(w http.ResponseWriter, r *http.Request, next handlerFunc, capturePathHint func(r *http.Request) string) error {
+	//nolint:ifshort
 	startTime := timeNow()
 
 	cw := NewCaptureWriter(w, maxCaptureSize)

--- a/capture.go
+++ b/capture.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/speakeasy-api/speakeasy-go-sdk/internal/log"
@@ -62,9 +63,13 @@ func (s *Speakeasy) handleRequestResponseError(w http.ResponseWriter, r *http.Re
 		pathHint = c.pathHint
 	}
 
-	// Assuming response is done
-	go s.captureRequestResponse(cw, r, startTime, pathHint, c)
-
+	// Used for load testing: set this to true and the capture GRPC call is invoked inline.
+	// This will cause the endpoint latency to be added to the GRPC request/response latency
+	if os.Getenv("SPEAKEASY_SDK_CAPTURE_INLINE") == "true" {
+		s.captureRequestResponse(cw, r, startTime, pathHint, c)
+	} else {
+		go s.captureRequestResponse(cw, r, startTime, pathHint, c)
+	}
 	return err
 }
 

--- a/capture.go
+++ b/capture.go
@@ -74,6 +74,7 @@ func (s *Speakeasy) handleRequestResponseError(w http.ResponseWriter, r *http.Re
 	return err
 }
 
+//nolint:nolintlint,contextcheck
 func (s *Speakeasy) captureRequestResponse(cw *captureWriter, r *http.Request, startTime time.Time, pathHint string, c *controller) {
 	var ctx context.Context = valueOnlyContext{r.Context()}
 

--- a/middleware.go
+++ b/middleware.go
@@ -20,7 +20,7 @@ func Middleware(next http.Handler) http.Handler {
 // Currently only gorilla/mux, go-chi/chi routers and the http.DefaultServerMux are supported for automatically
 // capturing path hints. Otherwise path hints can be supplied by a handler through the speakeasy MiddlewareController.
 //
-//nolint:contextcheck
+//nolint:nolintlint,contextcheck
 func (s *Speakeasy) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		s.handleRequestResponse(w, r, next.ServeHTTP, func(r *http.Request) string {

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -137,7 +137,7 @@ func TestSpeakeasy_Middleware_Capture_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance := speakeasy.New(speakeasy.Config{
+			sdkInstance, err := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -156,6 +156,7 @@ func TestSpeakeasy_Middleware_Capture_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
+			assert.Nil(t, err)
 
 			h := sdkInstance.Middleware(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				ctrl := speakeasy.MiddlewareController(req)
@@ -240,7 +241,6 @@ func TestSpeakeasy_Middleware_Capture_Success(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			var req *http.Request
-			var err error
 			if tt.Args.Body == "" {
 				req, err = http.NewRequest(tt.Args.Method, tt.Args.URL, nil)
 			} else {
@@ -342,7 +342,7 @@ func TestSpeakeasy_Middleware_URL_Resolve_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance := speakeasy.New(speakeasy.Config{
+			sdkInstance, err := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -357,6 +357,7 @@ func TestSpeakeasy_Middleware_URL_Resolve_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
+			assert.Nil(t, err)
 
 			r := mux.NewRouter()
 			r.Use(sdkInstance.Middleware)
@@ -440,7 +441,7 @@ func TestSpeakeasy_Middleware_GorillaMux_PathHint_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance := speakeasy.New(speakeasy.Config{
+			sdkInstance, err := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -450,6 +451,7 @@ func TestSpeakeasy_Middleware_GorillaMux_PathHint_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
+			assert.Nil(t, err)
 
 			r := mux.NewRouter()
 			r.Use(sdkInstance.Middleware)
@@ -519,7 +521,7 @@ func TestSpeakeasy_Middleware_Chi_PathHint_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance := speakeasy.New(speakeasy.Config{
+			sdkInstance, err := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -529,6 +531,7 @@ func TestSpeakeasy_Middleware_Chi_PathHint_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
+			assert.Nil(t, err)
 
 			r := chi.NewRouter()
 			r.Use(sdkInstance.Middleware)
@@ -584,7 +587,7 @@ func TestSpeakeasy_Middleware_ServerMux_PathHint_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance := speakeasy.New(speakeasy.Config{
+			sdkInstance, err := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -594,6 +597,7 @@ func TestSpeakeasy_Middleware_ServerMux_PathHint_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
+			assert.Nil(t, err)
 
 			r := http.DefaultServeMux
 
@@ -641,7 +645,7 @@ func TestSpeakeasy_GinMiddleware_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance := speakeasy.New(speakeasy.Config{
+			sdkInstance, err := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -651,6 +655,7 @@ func TestSpeakeasy_GinMiddleware_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
+			assert.Nil(t, err)
 
 			r := gin.Default()
 			r.Use(sdkInstance.GinMiddleware)
@@ -738,7 +743,6 @@ func TestSpeakeasy_GinMiddleware_Success(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			var req *http.Request
-			var err error
 			if tt.Args.Body == "" {
 				req, err = http.NewRequest(tt.Args.Method, tt.Args.URL, nil)
 			} else {
@@ -817,7 +821,7 @@ func TestSpeakeasy_GinMiddleware_PathHint_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance := speakeasy.New(speakeasy.Config{
+			sdkInstance, err := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -827,6 +831,7 @@ func TestSpeakeasy_GinMiddleware_PathHint_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
+			assert.Nil(t, err)
 
 			r := gin.Default()
 			r.Use(sdkInstance.GinMiddleware)
@@ -881,7 +886,7 @@ func TestSpeakeasy_EchoMiddleware_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance := speakeasy.New(speakeasy.Config{
+			sdkInstance, err := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -891,6 +896,7 @@ func TestSpeakeasy_EchoMiddleware_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
+			assert.Nil(t, err)
 
 			r := echo.New()
 			r.Use(sdkInstance.EchoMiddleware)
@@ -980,7 +986,6 @@ func TestSpeakeasy_EchoMiddleware_Success(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			var req *http.Request
-			var err error
 			if tt.Args.Body == "" {
 				req, err = http.NewRequest(tt.Args.Method, tt.Args.URL, nil)
 			} else {
@@ -1059,7 +1064,7 @@ func TestSpeakeasy_EchoMiddleware_PathHint_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance := speakeasy.New(speakeasy.Config{
+			sdkInstance, err := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -1069,6 +1074,7 @@ func TestSpeakeasy_EchoMiddleware_PathHint_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
+			assert.Nil(t, err)
 
 			r := echo.New()
 			r.Use(sdkInstance.EchoMiddleware)
@@ -1131,7 +1137,7 @@ func TestSpeakeasy_Middleware_Capture_CustomerID_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance := speakeasy.New(speakeasy.Config{
+			sdkInstance, err := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -1141,6 +1147,7 @@ func TestSpeakeasy_Middleware_Capture_CustomerID_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
+			assert.Nil(t, err)
 
 			w := httptest.NewRecorder()
 

--- a/speakeasy.go
+++ b/speakeasy.go
@@ -29,7 +29,7 @@ const (
 )
 
 var (
-	speakeasyVersion = "1.4.0" // TODO get this from CI
+	speakeasyVersion = "1.5.0" // TODO get this from CI
 	serverURL        = "grpc.prod.speakeasyapi.dev:443"
 
 	defaultInstance *Speakeasy

--- a/speakeasy.go
+++ b/speakeasy.go
@@ -29,7 +29,7 @@ const (
 )
 
 var (
-	speakeasyVersion = "1.3.4" // TODO get this from CI
+	speakeasyVersion = "1.4.0" // TODO get this from CI
 	serverURL        = "grpc.prod.speakeasyapi.dev:443"
 
 	defaultInstance *Speakeasy
@@ -63,29 +63,39 @@ type Speakeasy struct {
 
 // Configure allows you to configure the default instance of the Speakeasy SDK.
 // Use this if you will use the same API Key for all connected APIs.
-func Configure(config Config) {
-	defaultInstance = New(config)
+func Configure(config Config) error {
+	globalInstance, err := New(config)
+	defaultInstance = globalInstance
+	return err
 }
 
 // New creates a new instance of the Speakeasy SDK.
 // This allows you to create multiple instances of the SDK
 // for specifying different API Keys for different APIs.
-func New(config Config) *Speakeasy {
+func New(config Config) (*Speakeasy, error) {
 	s := &Speakeasy{}
-	s.configure(config)
+	err := s.configure(config)
 
-	return s
+	return s, err
 }
 
 func GetEmbedAccessToken(ctx context.Context, req *embedaccesstoken.EmbedAccessTokenRequest) (string, error) {
 	return defaultInstance.GetEmbedAccessToken(ctx, req)
 }
 
+func Close() error {
+	return defaultInstance.Close()
+}
+
 func (s *Speakeasy) GetEmbedAccessToken(ctx context.Context, req *embedaccesstoken.EmbedAccessTokenRequest) (string, error) {
 	return s.grpcClient.GetEmbedAccessToken(ctx, req)
 }
 
-func (s *Speakeasy) configure(cfg Config) {
+func (s *Speakeasy) Close() error {
+	return s.grpcClient.conn.Close()
+}
+
+func (s *Speakeasy) configure(cfg Config) error {
 	mustValidateConfig(cfg)
 
 	// The below environment variables allow the overriding of the location of the ingest server.
@@ -107,7 +117,9 @@ func (s *Speakeasy) configure(cfg Config) {
 
 	s.config = cfg
 
-	s.grpcClient = newGRPCClient(s.config.APIKey, configuredServerURL, secure, s.config.GRPCDialer)
+	grpcClient, err := newGRPCClient(context.Background(), s.config.APIKey, configuredServerURL, secure, s.config.GRPCDialer)
+	s.grpcClient = grpcClient
+	return err
 }
 
 func mustValidateConfig(cfg Config) {

--- a/speakeasy_test.go
+++ b/speakeasy_test.go
@@ -69,7 +69,8 @@ func TestConfigure_Success(t *testing.T) {
 				os.Setenv("SPEAKEASY_SERVER_SECURE", strconv.FormatBool(*tt.fields.envSecure))
 			}
 
-			sdkInstance := speakeasy.New(tt.args.config)
+			sdkInstance, err := speakeasy.New(tt.args.config)
+			assert.Nil(t, err)
 			assert.NotNil(t, sdkInstance)
 
 			config := sdkInstance.ExportGetSpeakeasyConfig()
@@ -163,7 +164,7 @@ func TestConfigure_Error(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.PanicsWithError(t, tt.wantErr, func() {
-				speakeasy.New(tt.args.config)
+				_, _ = speakeasy.New(tt.args.config)
 			})
 		})
 	}

--- a/testdata/captures_basic_request_and_no_response_body_output.json
+++ b/testdata/captures_basic_request_and_no_response_body_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.3.4"
+      "version": "1.4.0"
     },
     "entries": [
       {

--- a/testdata/captures_basic_request_and_no_response_body_output.json
+++ b/testdata/captures_basic_request_and_no_response_body_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "entries": [
       {

--- a/testdata/captures_basic_request_and_response_output.json
+++ b/testdata/captures_basic_request_and_response_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.3.4"
+      "version": "1.4.0"
     },
     "entries": [
       {

--- a/testdata/captures_basic_request_and_response_output.json
+++ b/testdata/captures_basic_request_and_response_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "entries": [
       {

--- a/testdata/captures_basic_request_and_response_with_different_content_types_output.json
+++ b/testdata/captures_basic_request_and_response_with_different_content_types_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.3.4"
+      "version": "1.4.0"
     },
     "entries": [
       {

--- a/testdata/captures_basic_request_and_response_with_different_content_types_output.json
+++ b/testdata/captures_basic_request_and_response_with_different_content_types_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "entries": [
       {

--- a/testdata/captures_basic_request_and_response_with_no_response_header_set_output.json
+++ b/testdata/captures_basic_request_and_response_with_no_response_header_set_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.3.4"
+      "version": "1.4.0"
     },
     "entries": [
       {

--- a/testdata/captures_basic_request_and_response_with_no_response_header_set_output.json
+++ b/testdata/captures_basic_request_and_response_with_no_response_header_set_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "entries": [
       {

--- a/testdata/captures_basic_request_and_response_with_repeat_headers_output.json
+++ b/testdata/captures_basic_request_and_response_with_repeat_headers_output.json
@@ -3,7 +3,7 @@
     "comment": "request capture for http://test.com/test",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "version": "1.2",
     "entries": [

--- a/testdata/captures_basic_request_and_response_with_repeat_headers_output.json
+++ b/testdata/captures_basic_request_and_response_with_repeat_headers_output.json
@@ -3,7 +3,7 @@
     "comment": "request capture for http://test.com/test",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.3.4"
+      "version": "1.4.0"
     },
     "version": "1.2",
     "entries": [

--- a/testdata/captures_basic_request_with_nano_precision_output.json
+++ b/testdata/captures_basic_request_with_nano_precision_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.3.4"
+      "version": "1.4.0"
     },
     "entries": [
       {

--- a/testdata/captures_basic_request_with_nano_precision_output.json
+++ b/testdata/captures_basic_request_with_nano_precision_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "entries": [
       {

--- a/testdata/captures_cookies_output.json
+++ b/testdata/captures_cookies_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.3.4"
+      "version": "1.4.0"
     },
     "entries": [
       {

--- a/testdata/captures_cookies_output.json
+++ b/testdata/captures_cookies_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "entries": [
       {

--- a/testdata/captures_masked_request_response_output.json
+++ b/testdata/captures_masked_request_response_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.3.4"
+      "version": "1.4.0"
     },
     "entries": [
       {
@@ -14,23 +14,23 @@
           "url": "http://test.com/test?querytest1=test1\u0026querytest2=__masked__\u0026querytest3=_____",
           "httpVersion": "HTTP/1.1",
           "cookies": [
-            { 
+            {
               "name": "cookie1",
               "value": "value1"
             },
-            { 
+            {
               "name": "cookie2",
-              "value": "__masked__" 
+              "value": "__masked__"
             },
-            { 
+            {
               "name": "cookie3",
               "value": "_____"
             }
           ],
           "headers": [
             {
-              "name": "Accept-Encoding", 
-              "value": "gzip, deflate" 
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
             },
             {
               "name": "Authorization",

--- a/testdata/captures_masked_request_response_output.json
+++ b/testdata/captures_masked_request_response_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "entries": [
       {

--- a/testdata/captures_no_response_body_when_not_modified_output.json
+++ b/testdata/captures_no_response_body_when_not_modified_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.3.4"
+      "version": "1.4.0"
     },
     "entries": [
       {

--- a/testdata/captures_no_response_body_when_not_modified_output.json
+++ b/testdata/captures_no_response_body_when_not_modified_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "entries": [
       {

--- a/testdata/captures_post_request_with_body_output.json
+++ b/testdata/captures_post_request_with_body_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.3.4"
+      "version": "1.4.0"
     },
     "entries": [
       {

--- a/testdata/captures_post_request_with_body_output.json
+++ b/testdata/captures_post_request_with_body_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "entries": [
       {

--- a/testdata/captures_query_params_output.json
+++ b/testdata/captures_query_params_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.3.4"
+      "version": "1.4.0"
     },
     "entries": [
       {

--- a/testdata/captures_query_params_output.json
+++ b/testdata/captures_query_params_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "entries": [
       {

--- a/testdata/captures_redirect_output.json
+++ b/testdata/captures_redirect_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.3.4"
+      "version": "1.4.0"
     },
     "entries": [
       {

--- a/testdata/captures_redirect_output.json
+++ b/testdata/captures_redirect_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "entries": [
       {

--- a/testdata/drops_request_and_response_bodies_when_request_body_too_large_output.json
+++ b/testdata/drops_request_and_response_bodies_when_request_body_too_large_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.3.4"
+      "version": "1.4.0"
     },
     "entries": [
       {

--- a/testdata/drops_request_and_response_bodies_when_request_body_too_large_output.json
+++ b/testdata/drops_request_and_response_bodies_when_request_body_too_large_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "entries": [
       {

--- a/testdata/drops_response_body_when_too_large_output.json
+++ b/testdata/drops_response_body_when_too_large_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.3.4"
+      "version": "1.4.0"
     },
     "entries": [
       {

--- a/testdata/drops_response_body_when_too_large_output.json
+++ b/testdata/drops_response_body_when_too_large_output.json
@@ -3,7 +3,7 @@
     "version": "1.2",
     "creator": {
       "name": "speakeasy-go-sdk",
-      "version": "1.4.0"
+      "version": "1.5.0"
     },
     "entries": [
       {

--- a/transport.go
+++ b/transport.go
@@ -74,12 +74,14 @@ func (c *GRPCClient) GetEmbedAccessToken(ctx context.Context, req *embedaccessto
 	return res.AccessToken, nil
 }
 
-func (c *GRPCClient) getConn(ctx context.Context) (*grpc.ClientConn, error) {
+func (c *GRPCClient) getConn(_ context.Context) (*grpc.ClientConn, error) {
 	// TODO: when the interface of the speakeasy middleware instantiation is changed to enable an error to be propagated
 	//       to the callee, create the connection inline with the middleware instantiation.
 	c.Lock()
 	defer c.Unlock()
 	if c.conn == nil {
+		// explicitly in background
+		//nolint:contextCheck
 		conn, err := createConn(context.Background(), c.secure, c.serverURL, c.grpcDialer)
 		if err != nil {
 			return nil, err

--- a/transport.go
+++ b/transport.go
@@ -76,7 +76,7 @@ func (c *GRPCClient) GetEmbedAccessToken(ctx context.Context, req *embedaccessto
 
 func (c *GRPCClient) getConn(ctx context.Context) (*grpc.ClientConn, error) {
 	// TODO: when the interface of the speakeasy middleware instantiation is changed to enable an error to be propagated
-	//       to the caller client, create the connection inline with the middleware instantiation.
+	//       to the callee, create the connection inline with the middleware instantiation.
 	c.Lock()
 	defer c.Unlock()
 	if c.conn == nil {

--- a/transport.go
+++ b/transport.go
@@ -32,9 +32,10 @@ type GRPCClient struct {
 
 func newGRPCClient(apiKey, serverURL string, secure bool, grpcDialer DialerFunc) *GRPCClient {
 	return &GRPCClient{
-		apiKey:    apiKey,
-		serverURL: serverURL,
-		secure:    secure,
+		apiKey:     apiKey,
+		serverURL:  serverURL,
+		secure:     secure,
+		grpcDialer: grpcDialer,
 	}
 }
 
@@ -74,6 +75,8 @@ func (c *GRPCClient) GetEmbedAccessToken(ctx context.Context, req *embedaccessto
 }
 
 func (c *GRPCClient) getConn(ctx context.Context) (*grpc.ClientConn, error) {
+	// TODO: when the interface of the speakeasy middleware instantiation is changed to enable an error to be propagated
+	//       to the caller client, create the connection inline with the middleware instantiation.
 	c.Lock()
 	defer c.Unlock()
 	if c.conn == nil {


### PR DESCRIPTION
The GRPC Client has a [resilient connection pool as part of the protocol](https://github.com/grpc/grpc/blob/master/doc/load-balancing.md). In the event of a server-failure, an implicit backoff is created, but the [documentation implies the ClientConnection is kept alive](https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md).

This change causes the GRPC Client to not be re-created between RPC calls. This adhere's to GRPC [best-practices documentation I can find online](https://grpc.io/docs/what-is-grpc/core-concepts/), and [examples](https://github.com/grpc/grpc-go/blob/master/examples/route_guide/client/client.go#L171)