### PR TITLE
chore: prefer panic on dial error

### DIFF
--- a/middleware_test.go
+++ b/middleware_test.go
@@ -137,7 +137,7 @@ func TestSpeakeasy_Middleware_Capture_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance, err := speakeasy.New(speakeasy.Config{
+			sdkInstance := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -156,7 +156,6 @@ func TestSpeakeasy_Middleware_Capture_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
-			assert.Nil(t, err)
 
 			h := sdkInstance.Middleware(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 				ctrl := speakeasy.MiddlewareController(req)
@@ -241,6 +240,7 @@ func TestSpeakeasy_Middleware_Capture_Success(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			var req *http.Request
+			var err error
 			if tt.Args.Body == "" {
 				req, err = http.NewRequest(tt.Args.Method, tt.Args.URL, nil)
 			} else {
@@ -342,7 +342,7 @@ func TestSpeakeasy_Middleware_URL_Resolve_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance, err := speakeasy.New(speakeasy.Config{
+			sdkInstance := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -357,7 +357,6 @@ func TestSpeakeasy_Middleware_URL_Resolve_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
-			assert.Nil(t, err)
 
 			r := mux.NewRouter()
 			r.Use(sdkInstance.Middleware)
@@ -441,7 +440,7 @@ func TestSpeakeasy_Middleware_GorillaMux_PathHint_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance, err := speakeasy.New(speakeasy.Config{
+			sdkInstance := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -451,7 +450,6 @@ func TestSpeakeasy_Middleware_GorillaMux_PathHint_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
-			assert.Nil(t, err)
 
 			r := mux.NewRouter()
 			r.Use(sdkInstance.Middleware)
@@ -521,7 +519,7 @@ func TestSpeakeasy_Middleware_Chi_PathHint_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance, err := speakeasy.New(speakeasy.Config{
+			sdkInstance := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -531,7 +529,6 @@ func TestSpeakeasy_Middleware_Chi_PathHint_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
-			assert.Nil(t, err)
 
 			r := chi.NewRouter()
 			r.Use(sdkInstance.Middleware)
@@ -587,7 +584,7 @@ func TestSpeakeasy_Middleware_ServerMux_PathHint_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance, err := speakeasy.New(speakeasy.Config{
+			sdkInstance := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -597,7 +594,6 @@ func TestSpeakeasy_Middleware_ServerMux_PathHint_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
-			assert.Nil(t, err)
 
 			r := http.DefaultServeMux
 
@@ -645,7 +641,7 @@ func TestSpeakeasy_GinMiddleware_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance, err := speakeasy.New(speakeasy.Config{
+			sdkInstance := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -655,7 +651,6 @@ func TestSpeakeasy_GinMiddleware_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
-			assert.Nil(t, err)
 
 			r := gin.Default()
 			r.Use(sdkInstance.GinMiddleware)
@@ -743,6 +738,7 @@ func TestSpeakeasy_GinMiddleware_Success(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			var req *http.Request
+			var err error
 			if tt.Args.Body == "" {
 				req, err = http.NewRequest(tt.Args.Method, tt.Args.URL, nil)
 			} else {
@@ -821,7 +817,7 @@ func TestSpeakeasy_GinMiddleware_PathHint_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance, err := speakeasy.New(speakeasy.Config{
+			sdkInstance := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -831,7 +827,6 @@ func TestSpeakeasy_GinMiddleware_PathHint_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
-			assert.Nil(t, err)
 
 			r := gin.Default()
 			r.Use(sdkInstance.GinMiddleware)
@@ -886,7 +881,7 @@ func TestSpeakeasy_EchoMiddleware_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance, err := speakeasy.New(speakeasy.Config{
+			sdkInstance := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -896,7 +891,6 @@ func TestSpeakeasy_EchoMiddleware_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
-			assert.Nil(t, err)
 
 			r := echo.New()
 			r.Use(sdkInstance.EchoMiddleware)
@@ -986,6 +980,7 @@ func TestSpeakeasy_EchoMiddleware_Success(t *testing.T) {
 			w := httptest.NewRecorder()
 
 			var req *http.Request
+			var err error
 			if tt.Args.Body == "" {
 				req, err = http.NewRequest(tt.Args.Method, tt.Args.URL, nil)
 			} else {
@@ -1064,7 +1059,7 @@ func TestSpeakeasy_EchoMiddleware_PathHint_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance, err := speakeasy.New(speakeasy.Config{
+			sdkInstance := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -1074,7 +1069,6 @@ func TestSpeakeasy_EchoMiddleware_PathHint_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
-			assert.Nil(t, err)
 
 			r := echo.New()
 			r.Use(sdkInstance.EchoMiddleware)
@@ -1137,7 +1131,7 @@ func TestSpeakeasy_Middleware_Capture_CustomerID_Success(t *testing.T) {
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 
-			sdkInstance, err := speakeasy.New(speakeasy.Config{
+			sdkInstance := speakeasy.New(speakeasy.Config{
 				APIKey:    testAPIKey,
 				ApiID:     testApiID,
 				VersionID: testVersionID,
@@ -1147,7 +1141,6 @@ func TestSpeakeasy_Middleware_Capture_CustomerID_Success(t *testing.T) {
 					wg.Done()
 				}),
 			})
-			assert.Nil(t, err)
 
 			w := httptest.NewRecorder()
 

--- a/speakeasy.go
+++ b/speakeasy.go
@@ -63,20 +63,18 @@ type Speakeasy struct {
 
 // Configure allows you to configure the default instance of the Speakeasy SDK.
 // Use this if you will use the same API Key for all connected APIs.
-func Configure(config Config) error {
-	globalInstance, err := New(config)
+func Configure(config Config) {
+	globalInstance := New(config)
 	defaultInstance = globalInstance
-	return err
 }
 
 // New creates a new instance of the Speakeasy SDK.
 // This allows you to create multiple instances of the SDK
 // for specifying different API Keys for different APIs.
-func New(config Config) (*Speakeasy, error) {
+func New(config Config) *Speakeasy {
 	s := &Speakeasy{}
-	err := s.configure(config)
-
-	return s, err
+	s.configure(config)
+	return s
 }
 
 func GetEmbedAccessToken(ctx context.Context, req *embedaccesstoken.EmbedAccessTokenRequest) (string, error) {
@@ -95,7 +93,7 @@ func (s *Speakeasy) Close() error {
 	return s.grpcClient.conn.Close()
 }
 
-func (s *Speakeasy) configure(cfg Config) error {
+func (s *Speakeasy) configure(cfg Config) {
 	mustValidateConfig(cfg)
 
 	// The below environment variables allow the overriding of the location of the ingest server.
@@ -119,7 +117,9 @@ func (s *Speakeasy) configure(cfg Config) error {
 
 	grpcClient, err := newGRPCClient(context.Background(), s.config.APIKey, configuredServerURL, secure, s.config.GRPCDialer)
 	s.grpcClient = grpcClient
-	return err
+	if err != nil {
+		panic(err)
+	}
 }
 
 func mustValidateConfig(cfg Config) {

--- a/speakeasy_test.go
+++ b/speakeasy_test.go
@@ -69,8 +69,7 @@ func TestConfigure_Success(t *testing.T) {
 				os.Setenv("SPEAKEASY_SERVER_SECURE", strconv.FormatBool(*tt.fields.envSecure))
 			}
 
-			sdkInstance, err := speakeasy.New(tt.args.config)
-			assert.Nil(t, err)
+			sdkInstance := speakeasy.New(tt.args.config)
 			assert.NotNil(t, sdkInstance)
 
 			config := sdkInstance.ExportGetSpeakeasyConfig()
@@ -164,7 +163,7 @@ func TestConfigure_Error(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.PanicsWithError(t, tt.wantErr, func() {
-				_, _ = speakeasy.New(tt.args.config)
+				_ = speakeasy.New(tt.args.config)
 			})
 		})
 	}


### PR DESCRIPTION
Reverts to prior API interface after running tests and before releasing v1.5.0.

The `grpc.DialContext` propagated an error to `speakeasy.New`. However, after code-inspection and integration assessment it is deemed to only produces an error on misconfiguration, because we're configuring the DialContext in a non-blocking manner.

In all other cases for misconfiguration, the current approach is to `panic` upon an error. This ensure we do the same if the GRPC connection is similarly misconfigured. It does not appear currently possible to misconfigure the GRPC connection in such a way that this error condition is triggered.